### PR TITLE
change ports in docker-compose.yml

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ../
       dockerfile: Dockerfile
     ports:
-      - "7860:7860"
-      - "1337:1337"
+      - "7861:7860"
+      - "1338:1337"
     volumes:
       - ../config.json:/app/config.json
     env_file:


### PR DESCRIPTION
Для того чтобы запустить докер версию NeurogenGPT
нужно перейти в папку docker-compose 
Убедится что копии контейнеров не было сделано,  командой docker ps
погасить уже имеющиеся контейнеры если такие есть через dokcer compose donw -v

и запустить образ через docker compose up -d
WebUi будет доступен по адресу http://localhost:7861/